### PR TITLE
Resolve unique key prop warning in TopItems#render()

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ class Item extends React.Component {
     let item = this.props.store;
 
     return (
-      <div key={item.id}>
+      <div>
         <h1><a href={item.url}>{item.title}</a></h1>
         <h2>{item.score} - {item.by.id}</h2>
         <hr />
@@ -34,7 +34,7 @@ Item = Relay.createContainer(Item, {
 class TopItems extends React.Component {
   render() {
     let items = this.props.store.stories.map(
-      store => <Item store={store} />
+      (store, idx) => <Item key={idx} store={store} />
     );
     let variables = this.props.relay.variables;
     let currentStoryType = (this.state && this.state.storyType) || variables.storyType;


### PR DESCRIPTION
Resolves https://github.com/clayallsopp/relay-101/issues/1

`TopItems` generates an array of `Item` components, each of those requires a key prop. Previously the key was specified on Items containing `<div>`, however, it needs to be set by it's parent. Moving that up, and using the iterators index does the trick.
